### PR TITLE
Added the --version argument

### DIFF
--- a/stegcracker/__main__.py
+++ b/stegcracker/__main__.py
@@ -4,7 +4,7 @@ from argparse import ArgumentParser
 from distutils.spawn import find_executable
 from os.path import isfile
 
-from stegcracker import __url__, __description__
+from stegcracker import __url__, __version__, __description__
 from stegcracker.cracker import Cracker
 from stegcracker.helpers import error, wc, handle_interrupt, DevNull, log, CustomHelpFormatter
 
@@ -21,7 +21,10 @@ def main():
 
         sys.stderr = DevNull()
 
-    log(f'StegCracker - ({__url__})',)
+    if any(i in sys.argv for i in ('-v', '--version')):
+        return print(__version__)
+
+    log(f'StegCracker {__version__} - ({__url__})',)
     log(f'Copyright (c) {datetime.now().year} - Luke Paris (Paradoxis)')
     log('')
 
@@ -62,6 +65,9 @@ def main():
         'By default, all logging / error messages are printed to stderr (making '
         'piping to other processes easier).'
     ), default=False)
+
+    args.add_argument('-v', '--version', action='store_true', help=(
+        'Print the current version number and exit.'))
 
     args.add_argument('-V', '--verbose', action='store_true', help=(
         'Runs the program in "verbose mode", this will print additional '

--- a/tests/stegcracker.py
+++ b/tests/stegcracker.py
@@ -10,7 +10,7 @@ from contextlib import redirect_stdout, redirect_stderr
 from uuid import uuid4
 
 import stegcracker
-from stegcracker import __main__ as cli, cracker
+from stegcracker import __main__ as cli, cracker, __version__
 
 
 FILE = 'tests/data/tom.jpg'
@@ -51,6 +51,20 @@ class CliTestCase(TestCase):
         self.assertIn('Copyright', stderr.read())
         self.assertEqual(crack.call_count, 0)
         self.assertNotEqual(code, 0)
+
+    @patch.object(cracker.Cracker, 'crack')
+    def test_version(self, crack):
+        """Ensure calling -v or --version is posaible and returns the current version number"""
+
+        for alias in ('-v', '--version'):
+            stdout, stderr, code = self.call(alias)
+            stdout = stdout.read().strip()
+
+	    self.assertEqual(stdout, __version__)
+
+            self.assertNotIn('Copyright', stderr.read())
+            self.assertEqual(crack.call_count, 0)
+            self.assertNotEqual(code, 0)
 
     @patch.object(cracker.Cracker, 'crack')
     def test_default_help(self, crack):

--- a/tests/stegcracker.py
+++ b/tests/stegcracker.py
@@ -54,15 +54,14 @@ class CliTestCase(TestCase):
 
     @patch.object(cracker.Cracker, 'crack')
     def test_version(self, crack):
-        """Ensure calling -v or --version is posaible and returns the current version number"""
+        """Ensure calling -v or --version is possible and returns the current version number"""
 
         for alias in ('-v', '--version'):
             stdout, stderr, code = self.call(alias)
             stdout = stdout.read().strip()
 
-	    self.assertEqual(stdout, __version__)
-
             self.assertNotIn('Copyright', stderr.read())
+            self.assertEqual(stdout, __version__)
             self.assertEqual(crack.call_count, 0)
             self.assertNotEqual(code, 0)
 

--- a/tests/stegcracker.py
+++ b/tests/stegcracker.py
@@ -63,7 +63,7 @@ class CliTestCase(TestCase):
             self.assertNotIn('Copyright', stderr.read())
             self.assertEqual(stdout, __version__)
             self.assertEqual(crack.call_count, 0)
-            self.assertNotEqual(code, 0)
+            self.assertEqual(code, 0)
 
     @patch.object(cracker.Cracker, 'crack')
     def test_default_help(self, crack):


### PR DESCRIPTION
Instead of having to list pip requirements, it's now possible to directly get the version number from the program itself. Syntax:

```
$ stegcracker --version
2.0.4
```

Or see the version number instantly:

```
$ stegcracker --help
StegCracker 2.0.4 - (https://github.com/Paradoxis/StegCracker)
Copyright (c) 2019 - Luke Paris (Paradoxis)

...
```